### PR TITLE
[BACKLOG-16035] - Create a registry allowing other Jahia modules to submit their tasks (incl. Java API/Interface)

### DIFF
--- a/src/main/java/org/jahia/modules/serveravailability/core/Task.java
+++ b/src/main/java/org/jahia/modules/serveravailability/core/Task.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.serveravailability.core;
+
+/**
+ * Task bean
+ */
+public interface Task {
+    /**
+     * Get Service attached to the task being monitored
+     *
+     * @return the key
+     */
+    String getService();
+
+    void setService(String service);
+
+    /**
+     * Get the name of the task associated with the service
+     *
+     * @return name
+     */
+    String getTaskName();
+
+    void setTaskName(String taskName);
+
+    /**
+     * Get When did the task start
+     *
+     * @return digested secret
+     */
+    String getStarted();
+
+    void setStarted(String started);
+}

--- a/src/main/java/org/jahia/modules/serveravailability/core/TaskBuilder.java
+++ b/src/main/java/org/jahia/modules/serveravailability/core/TaskBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.serveravailability.core;
+
+import javax.jcr.RepositoryException;
+
+/**
+ * Task builder
+ */
+public interface TaskBuilder {
+    /**
+     * Set task if you want ot use a predefined value
+     * @param task task value
+     * @return builder
+     */
+    public TaskBuilder setTask(Task task);
+
+    /**
+     * Create the task in the JCR. Session has to be saved to persist the task.
+     * @return the task value
+     * @throws javax.jcr.RepositoryException if repository operation fails
+     */
+    public String create() throws RepositoryException;
+}

--- a/src/main/java/org/jahia/modules/serveravailability/core/TaskService.java
+++ b/src/main/java/org/jahia/modules/serveravailability/core/TaskService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.serveravailability.core;
+
+import org.jahia.services.content.JCRSessionWrapper;
+
+import javax.jcr.RepositoryException;
+import java.util.stream.Stream;
+
+/**
+ * Service to handle tasks
+ */
+public interface TaskService {
+    /**
+     * You'll have to call create() on builder and save the session afterwards.
+     *
+     * @param task Task
+     * @return The task builder
+     * @throws javax.jcr.RepositoryException when repository operation fails
+     */
+    public TaskBuilder taskBuilder(Task task, JCRSessionWrapper session) throws RepositoryException;
+
+
+    /**
+     * Get the task  for the specified key, or null if it does not exist
+     *
+     * @param taskName     The task name
+     * @param session The session to use to retrieve the task
+     * @return Task
+     * @throws javax.jcr.RepositoryException when repository operation fails
+     */
+    public Task getTask(String taskName, JCRSessionWrapper session) throws RepositoryException;
+
+    /**
+     * Get all tasks
+     *
+     * @param session  The session to use to retrieve the tasks
+     * @return The tasks
+     * @throws javax.jcr.RepositoryException when repository operation fails
+     */
+    public Stream<Task> getTasks(JCRSessionWrapper session) throws RepositoryException;
+
+    /**
+     * Update task. You can change service, taskName
+     *
+     * @param task The updated task
+     * @param session The session
+     * @return true if operation succeeds, false if task does not exist
+     * @throws javax.jcr.RepositoryException when repository operation fails
+     */
+    public boolean updateTask(Task task, JCRSessionWrapper session) throws RepositoryException;
+
+    /**
+     * Delete an existing task
+     *
+     * @param taskName     The taskName
+     * @param session The session
+     * @return true if operation succeeds, false if task does not exist
+     * @throws javax.jcr.RepositoryException when repository operation fails
+     */
+    public boolean deleteTask(String taskName, JCRSessionWrapper session) throws RepositoryException;
+
+
+}

--- a/src/main/java/org/jahia/modules/serveravailability/registry/TaskImpl.java
+++ b/src/main/java/org/jahia/modules/serveravailability/registry/TaskImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.serveravailability.registry;
+
+import org.jahia.modules.serveravailability.core.Task;
+
+import java.util.Calendar;
+
+/**
+ * Implementation for Token details
+ */
+public class TaskImpl implements Task {
+    private String service;
+
+    private String taskName;
+
+    private String started;
+
+    /**
+     * New task
+     *
+     * @param service  service
+     * @param taskName taskName
+     * @param started  started
+     */
+    TaskImpl(String service, String taskName, String started) {
+        this.service = service;
+        this.taskName = taskName;
+        this.started = started;
+    }
+
+    @Override
+    public String getService() {
+        return service;
+    }
+
+    @Override
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    @Override
+    public String getTaskName() {
+        return taskName;
+    }
+
+    @Override
+    public void setTaskName(String taskName) {
+        this.taskName = taskName;
+    }
+
+    @Override
+    public String getStarted() {
+        return started;
+    }
+
+    @Override
+    public void setStarted(String started) {
+        this.started = started;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskImpl{" +
+                "service='" + service + '\'' +
+                ", taskName='" + taskName + '\'' +
+                ", started='" + started + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
Create a registry allowing other Jahia modules to submit their tasks (incl. Java API/Interface)

## JIRA

https://jira.jahia.org/browse/BACKLOG-16035


## Description

As a developer
I want to inform Jahia that my module is starting a task that shouldn’t be interrupted
In order to prevent the server from being restarted

This is the backend implementation of the registry, when a module registers a task, this task shows up in the API via BACKLOG-16030

This exposes a Java API/Interface allowing other Jahia modules to add and remote content in/from the registry