### PR TITLE
BACKLOG-16133 add module state example configs

### DIFF
--- a/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
@@ -1,3 +1,6 @@
 # default configuration
 #probes.testProbe.severity=HIGH
 #probes.testProbe.status=RED
+# example of module state config, comma-separated module names
+#probes.ModuleState.blacklist=channels,forms-core
+#probes.ModuleState.whitelist=seo,augmented-search


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-16113

## Description

Added example configuration for the sysadmin reference