### PR TITLE
QA-14328 : Add import-package to fix config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <jahia-module-signature>MCwCFBoRS08hYnN3QITTxSp+TSPfCtzxAhQ0sryYO+OLVoNu5wVFwr4dc65+xQ==</jahia-module-signature>
         <export-package>org.jahia.modules.sam</export-package>
         <yarn.arguments>build:production</yarn.arguments>
+        <jahia.modules.importPackage>org.osgi.service.cm</jahia.modules.importPackage>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14328

## Description

This is a bug in felix-scr - activate() does not receive config if it's there before starting the module. An import of configadmin seems to solve the activate() call .