### PR TITLE
BACKLOG-21210 : make sam works with jahia 8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.2.0</version>
+        <version>8.2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>server-availability-manager</artifactId>
     <name>Server Availability Manager</name>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </parent>
     <artifactId>server-availability-manager</artifactId>
     <name>Server Availability Manager</name>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Server Availability Manager) for running on a Jahia server.</description>
 
@@ -68,7 +68,7 @@
         <jahia-depends>graphql-dxm-provider</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
-        <jahia-module-signature>MCwCFDrSQPuQPKwXqe13Y16vW6FdRwVOAhRfhPauSFi/cyGuRqqV3pfVHJcrwg==</jahia-module-signature>
+        <jahia-module-signature>MCwCFBkjV4sr9oWrjWNdfdVDDQ7sdCs0AhQRRAtTOm1HC18ypfBBgty//jFZ+Q==</jahia-module-signature>
         <export-package>org.jahia.modules.sam</export-package>
         <import-package>
             graphql.annotations.annotationTypes;version="[7.2,8)",
@@ -80,6 +80,7 @@
             org.apache.commons.io;version="[1.4,2)",
             org.apache.commons.io.filefilter;version="[1.4,2)",
             org.apache.commons.lang;version="[2.6,3)",
+            org.apache.jackrabbit.api.stats,
             org.apache.jackrabbit.core,
             org.apache.jackrabbit.core.persistence,
             org.apache.jackrabbit.core.persistence.pool,


### PR DESCRIPTION
Following that change 
https://github.com/Jahia/jahia/blob/89aee45eb701dfa77e584376f6484314b1d4f0ca/jahia-parent/pom.xml#L73
the version range of `org.apache.jackrabbit.api` has been set to 1

Changing the parent version fixes the dependency issue 