### PR TITLE
Restore skipped tests

### DIFF
--- a/tests/cypress/e2e/api/checkProbes.spec.ts
+++ b/tests/cypress/e2e/api/checkProbes.spec.ts
@@ -127,7 +127,7 @@ describe('Health check', () => {
         });
     });
 
-    it.only('Check Probe coming from another bundle is accessible', () => {
+    it('Check Probe coming from another bundle is accessible', () => {
         cy.runProvisioningScript({fileName: 'test-disable.json'});
 
         cy.waitUntil(() => cy.task('sshCommand', sshCommands)


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14982

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Noticed some probe tests are being skipped due to added `.only` in one of the test.

I'm not sure if this was on purpose or we need to restore.

Related PR: https://github.com/Jahia/server-availability-manager/pull/104