### PR TITLE
BACKLOG-21616: Fix publishing issue with 8.2-SN parent

### DIFF
--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.0</version>
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>server-availability-manager-test-module</artifactId>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21616

Issue with publishing step ([here](https://github.com/Jahia/server-availability-manager/actions/runs/9117795458/job/25069575118#step:4:1932)) when merging to main branch: 

```
[FATAL] Non-resolvable parent POM for org.jahia.test:server-availability-manager-test-module:3.1.0-SNAPSHOT: 
The following artifacts could not be resolved: org.jahia.modules:jahia-modules:pom:8.2.0.0-SNAPSHOT (absent): 
Could not find artifact org.jahia.modules:jahia-modules:pom:8.2.0.0-SNAPSHOT in jahia-internal 
(https://devtools.jahia.com/nexus/content/groups/internal) and 'parent.relativePath' points at wrong local POM @ line 50, column 13
```
