### PR TITLE
BACKLOG-21616: Add db check for datastore probe

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -8,7 +8,7 @@ on:
       jahia_image:
         description: 'Jahia Image'
         required: true
-        default: 'jahia/jahia-ee:8'
+        default: 'jahia/jahia-ee:8.1'
       manifest:
         description: 'Provisioning manifest. Can be a local repository file in the tests folder or a publicly accessible link'
         required: true

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -82,7 +82,7 @@ jobs:
           timeout_minutes: 20
           testrail_milestone: Default
           tests_manifest: provisioning-manifest-build.yml
-          jahia_image: jahia/jahia-ee:8
+          jahia_image: jahia/jahia-ee:8.1
           should_use_build_artifacts: true
           should_skip_testrail: true
           github_artifact_name: sam-artifacts-${{ github.run_number }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -72,7 +72,7 @@ jobs:
           testrail_project: Server Availability Manager
           timeout_minutes: 20
           tests_manifest: provisioning-manifest-build.yml
-          jahia_image: jahia/jahia-ee:8
+          jahia_image: jahia/jahia-ee:8.1
           should_use_build_artifacts: true
           github_artifact_name: sam-artifacts-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}

--- a/src/main/java/org/jahia/modules/sam/healthcheck/probes/FileDatastoreProbe.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/probes/FileDatastoreProbe.java
@@ -7,6 +7,7 @@ import org.jahia.modules.sam.ProbeSeverity;
 import org.jahia.modules.sam.ProbeStatus;
 import org.jahia.services.content.JCRTemplate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +24,9 @@ public class FileDatastoreProbe implements Probe {
 
     private static final Logger logger = LoggerFactory.getLogger(FileDatastoreProbe.class);
 
+    @Reference(service=Probe.class, target="(component.name=org.jahia.modules.sam.healthcheck.probes.DBConnectivityProbe)")
+    private Probe dbConnectivityProbe;
+
     @Override
     public ProbeStatus getStatus() {
 
@@ -33,10 +37,16 @@ public class FileDatastoreProbe implements Probe {
             return Files.exists(datastorePath) && Files.isWritable(datastorePath) ?
                     new ProbeStatus("Datastore is healthy", ProbeStatus.Health.GREEN) :
                     new ProbeStatus("Could not perform write operation", ProbeStatus.Health.RED);
+
+        } else if (dbConnectivityProbe == null) {
+            return new ProbeStatus("Unable to check database connectivity for db datastore", ProbeStatus.Health.YELLOW);
+
+        // check db connectivity if datastore in db; reuse DBConnectivityProbe
+        } else if (dbConnectivityProbe.getStatus().getHealth().equals(ProbeStatus.Health.RED)) {
+            return new ProbeStatus("Database not available for db datastore", ProbeStatus.Health.RED);
         }
 
         return new ProbeStatus("Datastore is healthy", ProbeStatus.Health.GREEN);
-
     }
 
     private boolean isStoreFilesInDB() {

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,5 +1,5 @@
 JAHIA_VERSION=${JAHIA_VERSION:-LATEST}
-JAHIA_IMAGE=${JAHIA_IMAGE:-jahia/jahia-ee:8}
+JAHIA_IMAGE=${JAHIA_IMAGE:-jahia/jahia-ee:8.1}
 TESTS_IMAGE=${TESTS_IMAGE:-jahia/server-availability-manager:latest}
 MODULE_ID=${MODULE_ID:-server-availability-manager}
 MANIFEST=${MANIFEST:-provisioning-manifest-snapshot.yml}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21616

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

2.8-SN backport for PR https://github.com/Jahia/server-availability-manager/pull/121 and https://github.com/Jahia/server-availability-manager/pull/123