### PR TITLE
BACKLOG-22625: Add 'includes' param to filter list of probes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-signature>MCwCFBBKI2ZClWJmrUfUb8GQJP2kqEeMAhQ3huksKlBGF5mCCP+2a6Eq1T33JQ==</jahia-module-signature>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
         <export-package>org.jahia.modules.sam</export-package>
         <import-package>
             graphql.annotations.annotationTypes;version="[7.2,99)",

--- a/src/main/java/org/jahia/modules/sam/graphql/GqlHealthCheck.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/GqlHealthCheck.java
@@ -7,6 +7,7 @@ import org.jahia.modules.sam.ProbeSeverity;
 import org.jahia.modules.sam.healthcheck.ProbesRegistry;
 
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
@@ -16,15 +17,16 @@ import java.util.stream.Collectors;
 public class GqlHealthCheck {
 
     private ProbesRegistry probesRegistry;
-    private GqlProbeSeverity severityThreshold;
+    private final GqlProbeSeverity severityThreshold;
+    private final Collection<String> includes;
 
-    public GqlHealthCheck(GqlProbeSeverity severityThreshold) {
+    public GqlHealthCheck(GqlProbeSeverity severityThreshold, Collection<String> includes) {
+        this.includes = includes;
         if (severityThreshold != null) {
             this.severityThreshold = severityThreshold;
         } else {
             this.severityThreshold = GqlProbeSeverity.MEDIUM;
         }
-
     }
 
     @Inject
@@ -48,8 +50,8 @@ public class GqlHealthCheck {
     @GraphQLDescription("Probes registered in SAM for the requested severity")
     public List<GqlProbe> getProbes() {
         return probesRegistry.getProbes().stream()
-                .filter(p -> probesRegistry.getProbeSeverity(p).ordinal() >= ProbeSeverity
-                        .valueOf(severityThreshold.name()).ordinal())
+                .filter(p -> includes == null || includes.contains(p.getName()))
+                .filter(p -> probesRegistry.getProbeSeverity(p).ordinal() >= ProbeSeverity.valueOf(severityThreshold.name()).ordinal())
                 .map(GqlProbe::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/jahia/modules/sam/graphql/ServerAvailabilityQuery.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/ServerAvailabilityQuery.java
@@ -1,13 +1,11 @@
 package org.jahia.modules.sam.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminQuery;
 import org.jahia.modules.sam.TasksIdentificationService;
 import org.jahia.osgi.BundleUtils;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,8 +28,9 @@ public class ServerAvailabilityQuery {
     @GraphQLField
     @GraphQLDescription("HealthCheck node")
     public GqlHealthCheck getHealthCheck(
-            @GraphQLName("severity") @GraphQLDescription("Returns SAM probes with this severity or higher") GqlProbeSeverity severity) {
-        return new GqlHealthCheck(severity);
+            @GraphQLName("severity") @GraphQLDescription("Returns SAM probes with this severity or higher") GqlProbeSeverity severity,
+            @GraphQLName("includes") @GraphQLDescription("Returns only SAM probes with probe names included in this list") Collection<@GraphQLNonNull String> includes) {
+        return new GqlHealthCheck(severity, includes);
     }
 
     @GraphQLField

--- a/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
@@ -1,6 +1,5 @@
 package org.jahia.modules.sam.healthcheck;
 
-import org.apache.commons.io.output.WriterOutputStream;
 import org.jahia.modules.graphql.provider.dxm.security.GqlAccessDeniedException;
 import org.jahia.modules.sam.ProbeSeverity;
 import org.jahia.modules.sam.ProbeStatus;
@@ -17,17 +16,21 @@ import javax.servlet.http.*;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @SuppressWarnings({"java:S2226", "java:S1989"})
 @Component(service = {javax.servlet.http.HttpServlet.class, javax.servlet.Servlet.class}, property = {"alias=/healthcheck", "allow-api-token=true"})
 public class HealthCheckServlet extends HttpServlet {
     private HttpServlet gql;
     private ProbeSeverity defaultSeverity;
+    private String defaultIncludes;
     private ProbeStatus.Health statusThreshold;
+
+    @Reference(service = ProbesRegistry.class)
+    private ProbesRegistry probesRegistry;
+
     private PermissionService permissionService;
     private int statusCode;
 
@@ -35,6 +38,7 @@ public class HealthCheckServlet extends HttpServlet {
     public void activate(Map<String, Object> config) {
         //setting default values for probes
         defaultSeverity = (config.get("severity.default")!=null ? ProbeSeverity.valueOf((String) config.get("severity.default")) : ProbeSeverity.MEDIUM);
+        defaultIncludes = (config.get("includes.default") != null) ? (String) config.get("includes.default") : "";
         statusThreshold = (config.get("status.threshold")!=null ? ProbeStatus.Health.valueOf((String) config.get("status.threshold")) : ProbeStatus.Health.RED);
         statusCode = (config.get("status.code")!=null ? Integer.parseInt((String) config.get("status.code")) : 503);
     }
@@ -60,6 +64,18 @@ public class HealthCheckServlet extends HttpServlet {
             return;
         }
 
+        // Filter 'includes' param (or default includes) against valid probe names
+        String includesParam = Optional.ofNullable(req.getParameter("includes")).orElse(defaultIncludes);
+        String tmpIncludes = null;
+        if (!includesParam.isEmpty()) {
+            Set<String> includeSet = Stream.of(includesParam.split(",")).collect(Collectors.toCollection(HashSet::new));
+            tmpIncludes = probesRegistry.getProbes().stream()
+                    .filter(b -> includeSet.contains(b.getName()))
+                    .map(b -> "\"" + b.getName() + "\"")
+                    .collect(Collectors.joining(","));
+        }
+        String includes = tmpIncludes;
+
         HttpServletRequest requestWrapper = new HttpServletRequestWrapper(req) {
             @Override
             public boolean isAsyncSupported() {
@@ -69,10 +85,12 @@ public class HealthCheckServlet extends HttpServlet {
             @Override
             public String getParameter(String name) {
                 if (name.equals("query")) {
+                    String params = "severity: " + severity
+                            + ((includes != null) ? String.format(", includes: [%s]", includes) : "");
                     return "{\n" +
                             "  admin {\n" +
                             "    jahia {\n" +
-                            "      healthCheck(severity:" + severity + ") {\n" +
+                            "      healthCheck(" + params + ") {\n" +
                             "        status {\n" +
                             "          health\n" +
                             "          message\n" +

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.HealthCheckServlet.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.HealthCheckServlet.cfg
@@ -1,5 +1,6 @@
 # default configuration
 severity.default=MEDIUM
+includes.default=
 
 status.threshold=RED
 status.code=503

--- a/tests/cypress/e2e/api/checkProbes.spec.ts
+++ b/tests/cypress/e2e/api/checkProbes.spec.ts
@@ -35,38 +35,38 @@ describe('Health check', () => {
 
     it('Filters with "includes" parameter', () => {
         cy.runProvisioningScript({fileName: 'test-disable.json'});
-        
+
         cy.waitUntil(() => cy.task('sshCommand', sshCommands)
             .then(waitUntilTestFcnDisable), waitUntilOptions);
 
-        console.log("Return with blank filter");
+        console.log('Return with blank filter');
         healthCheck('LOW', []).should(r => {
             expect(r.probes).to.be.empty;
         });
 
-        console.log("Return one probe");
+        console.log('Return one probe');
         healthCheck('LOW', 'FileDatastore').should(r => {
             expect(r.probes.length).to.be.eq(1);
-            expect(r.probes[0].name).to.be.eq("FileDatastore");
+            expect(r.probes[0].name).to.be.eq('FileDatastore');
         });
 
-        console.log("Return more than one probe");
+        console.log('Return more than one probe');
         healthCheck('LOW', ['FileDatastore', 'DBConnectivity']).should(r => {
             expect(r.probes.length).to.be.eq(2);
-            const probeNames = r.probes?.map(r => r.name);
+            const probeNames = r.probes?.map(p => p.name);
             expect('FileDatastore').to.be.oneOf(probeNames);
             expect('DBConnectivity').to.be.oneOf(probeNames);
         });
 
-        console.log("Filter with only invalid probe");
+        console.log('Filter with only invalid probe');
         healthCheck('LOW', ['UndefinedProbe']).should(r => {
             expect(r.probes).to.be.empty;
         });
 
-        console.log("Filter invalid probe");
+        console.log('Filter invalid probe');
         healthCheck('LOW', ['FileDatastore', 'UndefinedProbe']).should(r => {
             expect(r.probes.length).to.be.eq(1);
-            expect(r.probes[0].name).to.be.eq("FileDatastore");
+            expect(r.probes[0].name).to.be.eq('FileDatastore');
         });
     });
 

--- a/tests/cypress/e2e/api/healthCheckServlet.spec.ts
+++ b/tests/cypress/e2e/api/healthCheckServlet.spec.ts
@@ -1,4 +1,4 @@
-const healthcheck = (qs) => {
+const healthcheck = qs => {
     return cy.request({
         url: `${Cypress.config().baseUrl}/modules/healthcheck`,
         qs,
@@ -16,27 +16,27 @@ const healthcheck = (qs) => {
 
 describe('healthcheck REST API test', () => {
     it('should return using "includes" parameter', () => {
-        console.log("Return with no filter");
+        console.log('Return with no filter');
         healthcheck({}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes).to.not.be.empty;
         });
 
-        console.log("Return with empty filter");
+        console.log('Return with empty filter');
         healthcheck({includes: undefined}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes).to.not.be.empty;
         });
 
-        console.log("Return one probe");
-        healthcheck({includes: "FileDatastore"}).should(response => {
+        console.log('Return one probe');
+        healthcheck({includes: 'FileDatastore'}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes?.length).to.eq(1);
             expect(response.body.probes[0]?.name).to.eq('FileDatastore');
         });
 
-        console.log("Return more than one probe");
-        healthcheck({includes: "FileDatastore,DBConnectivity"}).should(response => {
+        console.log('Return more than one probe');
+        healthcheck({includes: 'FileDatastore,DBConnectivity'}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes.length).to.be.eq(2);
             const probeNames = response.body.probes?.map(r => r.name);
@@ -44,19 +44,18 @@ describe('healthcheck REST API test', () => {
             expect('DBConnectivity').to.be.oneOf(probeNames);
         });
 
-        console.log("Filter with only invalid probe");
-        healthcheck({includes: "UndefinedProbe"}).should(response => {
+        console.log('Filter with only invalid probe');
+        healthcheck({includes: 'UndefinedProbe'}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes).to.be.empty;
         });
 
-        console.log("Filter invalid probe");
-        healthcheck({includes: "FileDatastore,UndefinedProbe"}).should(response => {
+        console.log('Filter invalid probe');
+        healthcheck({includes: 'FileDatastore,UndefinedProbe'}).should(response => {
             expect(response.status).to.eq(200);
             expect(response.body.probes.length).to.be.eq(1);
             const probeNames = response.body.probes?.map(r => r.name);
             expect('FileDatastore').to.be.oneOf(probeNames);
         });
     });
-
 });

--- a/tests/cypress/e2e/api/healthCheckServlet.spec.ts
+++ b/tests/cypress/e2e/api/healthCheckServlet.spec.ts
@@ -1,0 +1,62 @@
+const healthcheck = (qs) => {
+    return cy.request({
+        url: `${Cypress.config().baseUrl}/modules/healthcheck`,
+        qs,
+        headers: {
+            referer: Cypress.config().baseUrl
+        },
+        auth: {
+            user: 'root',
+            pass: Cypress.env('SUPER_USER_PASSWORD'),
+            sendImmediately: true
+        },
+        failOnStatusCode: false
+    });
+};
+
+describe('healthcheck REST API test', () => {
+    it('should return using "includes" parameter', () => {
+        console.log("Return with no filter");
+        healthcheck({}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.not.be.empty;
+        });
+
+        console.log("Return with empty filter");
+        healthcheck({includes: undefined}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.not.be.empty;
+        });
+
+        console.log("Return one probe");
+        healthcheck({includes: "FileDatastore"}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes?.length).to.eq(1);
+            expect(response.body.probes[0]?.name).to.eq('FileDatastore');
+        });
+
+        console.log("Return more than one probe");
+        healthcheck({includes: "FileDatastore,DBConnectivity"}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes.length).to.be.eq(2);
+            const probeNames = response.body.probes?.map(r => r.name);
+            expect('FileDatastore').to.be.oneOf(probeNames);
+            expect('DBConnectivity').to.be.oneOf(probeNames);
+        });
+
+        console.log("Filter with only invalid probe");
+        healthcheck({includes: "UndefinedProbe"}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.be.empty;
+        });
+
+        console.log("Filter invalid probe");
+        healthcheck({includes: "FileDatastore,UndefinedProbe"}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes.length).to.be.eq(1);
+            const probeNames = response.body.probes?.map(r => r.name);
+            expect('FileDatastore').to.be.oneOf(probeNames);
+        });
+    });
+
+});

--- a/tests/cypress/fixtures/healthcheck.graphql
+++ b/tests/cypress/fixtures/healthcheck.graphql
@@ -1,7 +1,7 @@
-query($severity: GqlProbeSeverity) {
+query($severity: GqlProbeSeverity, $includes: [String!]) {
     admin {
         jahia {
-            healthCheck(severity: $severity) {
+            healthCheck(severity: $severity, includes: $includes) {
                 status {
                     health
                     message

--- a/tests/cypress/support/gql.ts
+++ b/tests/cypress/support/gql.ts
@@ -37,7 +37,7 @@ export const deleteTask = (taskService: string, taskName: string, auth?: AuthMet
     });
 };
 
-export const healthCheck = (severity: string, auth?: AuthMethod): Chainable<any> => {
+export const healthCheck = (severity: string, includes?: [string?], auth?: AuthMethod): Chainable<any> => {
     if (auth) {
         cy.apolloClient(auth);
     }
@@ -45,9 +45,7 @@ export const healthCheck = (severity: string, auth?: AuthMethod): Chainable<any>
     return cy
         .apollo({
             queryFile: 'healthcheck.graphql',
-            variables: {
-                severity
-            },
+            variables: {severity, includes},
             errorPolicy: 'all'
         })
         .then((response: any) => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22625

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add new `includes` parameter when querying healthcheck for both graphql and REST APIs; added cypress tests 

