### PR TITLE
BACKLOG-22768: Add node cache load in Load API from ServerLoadProbe

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 14
           auditci_level: critical
 
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.2.0</version>
+        <version>8.1.4.0</version>
     </parent>
     <artifactId>server-availability-manager</artifactId>
     <name>Server Availability Manager</name>

--- a/src/main/java/org/jahia/modules/sam/graphql/Load.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/Load.java
@@ -2,6 +2,7 @@ package org.jahia.modules.sam.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
+import org.jahia.utils.JCRNodeCacheLoadAverage;
 import org.jahia.utils.JCRSessionLoadAverage;
 import org.jahia.utils.RequestLoadAverage;
 
@@ -18,5 +19,11 @@ public class Load {
     @GraphQLDescription("Get JCR Sessions load")
     public LoadValue getSessions() {
         return new LoadValue(JCRSessionLoadAverage.getInstance());
+    }
+
+    @GraphQLField
+    @GraphQLDescription("Get JCR Node Cache load across active sessions")
+    public LoadValue getCachedNodes() {
+        return new LoadValue(JCRNodeCacheLoadAverage.getInstance());
     }
 }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
@@ -10,6 +10,8 @@
 #probes.ServerLoad.requestLoadRedThreshold=70
 #probes.ServerLoad.sessionLoadYellowThreshold=40
 #probes.ServerLoad.sessionLoadRedThreshold=70
+#probes.ServerLoad.nodeCacheLoadYellowThreshold=1000
+#probes.ServerLoad.nodeCacheLoadRedThreshold=2000
 
 
 #example of SearchIndex probe config in ms

--- a/tests/cypress/fixtures/serverLoadProbe/set-default-threshold.json
+++ b/tests/cypress/fixtures/serverLoadProbe/set-default-threshold.json
@@ -5,7 +5,9 @@
       "probes.ServerLoad.requestLoadYellowThreshold": "40",
       "probes.ServerLoad.requestLoadRedThreshold": "70",
       "probes.ServerLoad.sessionLoadYellowThreshold": "40",
-      "probes.ServerLoad.sessionLoadRedThreshold": "70"
+      "probes.ServerLoad.sessionLoadRedThreshold": "70",
+      "probes.ServerLoad.nodeCacheLoadYellowThreshold": "1000",
+      "probes.ServerLoad.nodeCacheLoadRedThreshold": "2000"
     }
   }
 ]

--- a/tests/cypress/fixtures/serverLoadProbe/set-red-threshold.json
+++ b/tests/cypress/fixtures/serverLoadProbe/set-red-threshold.json
@@ -5,7 +5,9 @@
       "probes.ServerLoad.requestLoadYellowThreshold": "-1",
       "probes.ServerLoad.requestLoadRedThreshold": "-1",
       "probes.ServerLoad.sessionLoadYellowThreshold": "-1",
-      "probes.ServerLoad.sessionLoadRedThreshold": "-1"
+      "probes.ServerLoad.sessionLoadRedThreshold": "-1",
+      "probes.ServerLoad.nodeCacheLoadYellowThreshold": "-1",
+      "probes.ServerLoad.nodeCacheLoadRedThreshold": "-1"
     }
   }
 ]

--- a/tests/cypress/fixtures/serverLoadProbe/set-yellow-threshold.json
+++ b/tests/cypress/fixtures/serverLoadProbe/set-yellow-threshold.json
@@ -5,7 +5,9 @@
       "probes.ServerLoad.requestLoadYellowThreshold": "-1",
       "probes.ServerLoad.requestLoadRedThreshold": "70",
       "probes.ServerLoad.sessionLoadYellowThreshold": "-1",
-      "probes.ServerLoad.sessionLoadRedThreshold": "70"
+      "probes.ServerLoad.sessionLoadRedThreshold": "70",
+      "probes.ServerLoad.nodeCacheLoadYellowThreshold": "-1",
+      "probes.ServerLoad.nodeCacheLoadRedThreshold": "2000"
     }
   }
 ]

--- a/tests/package.json
+++ b/tests/package.json
@@ -17,11 +17,13 @@
     "@jahia/jahia-reporter": "^1.1.16",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.1",
-    "cypress": "^11.1.0",
-    "cypress-multi-reporters": "^1.5.0",
+    "cypress": "13.9.0",
+    "cypress-multi-reporters": "^1.6.3",
+    "cypress-terminal-report": "^5.3.7",
     "cypress-wait-until": "^1.7.2",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-chai-friendly": "^0.7.2",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-json": "^3.1.0",
@@ -31,8 +33,8 @@
     "mochawesome": "^7.0.1",
     "mochawesome-merge": "^4.2.0",
     "mochawesome-report-generator": "^6.0.1",
+    "node-ssh": "^12.0.4",
     "prettier": "^2.4.0",
-    "typescript": "^4.4.2",
-    "node-ssh": "^12.0.4"
+    "typescript": "^4.4.2"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -975,7 +975,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.6.0:
+buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -1307,10 +1307,10 @@ cypress-wait-until@^1.7.2:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
   integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
-cypress@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.1.0.tgz#b8f16495a8a5d8f9a7dd3374ae7b2cef45e9c779"
-  integrity sha512-kzizbG9s3p3ahWqxUwG/21NqLWEGtScMevMyUPeYlcmMX9RzVxWM18MkA3B4Cb3jKx72hSyIE2mHgHymfCM1bg==
+cypress@13.9.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.9.0.tgz#b529cfa8f8c39ba163ed0501a25bb5b09c143652"
+  integrity sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -1320,7 +1320,7 @@ cypress@^11.1.0:
     arch "^2.2.0"
     blob-util "^2.0.2"
     bluebird "^3.7.2"
-    buffer "^5.6.0"
+    buffer "^5.7.1"
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
@@ -1338,7 +1338,7 @@ cypress@^11.1.0:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
-    is-ci "^3.0.0"
+    is-ci "^3.0.1"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
@@ -2612,7 +2612,7 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-ci@^3.0.0:
+is-ci@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22768
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

2.8-SN backport of https://github.com/Jahia/server-availability-manager/pull/120