### PR TITLE
BACKLOG-22625: Add 'includes' param to filter list of probes

### DIFF
--- a/src/main/java/org/jahia/modules/sam/graphql/GqlHealthCheck.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/GqlHealthCheck.java
@@ -7,6 +7,7 @@ import org.jahia.modules.sam.ProbeSeverity;
 import org.jahia.modules.sam.healthcheck.ProbesRegistry;
 
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
@@ -16,15 +17,16 @@ import java.util.stream.Collectors;
 public class GqlHealthCheck {
 
     private ProbesRegistry probesRegistry;
-    private GqlProbeSeverity severityThreshold;
+    private final GqlProbeSeverity severityThreshold;
+    private final Collection<String> includes;
 
-    public GqlHealthCheck(GqlProbeSeverity severityThreshold) {
+    public GqlHealthCheck(GqlProbeSeverity severityThreshold, Collection<String> includes) {
+        this.includes = includes;
         if (severityThreshold != null) {
             this.severityThreshold = severityThreshold;
         } else {
             this.severityThreshold = GqlProbeSeverity.MEDIUM;
         }
-
     }
 
     @Inject
@@ -47,6 +49,7 @@ public class GqlHealthCheck {
     @GraphQLField
     public List<GqlProbe> getProbes() {
         return probesRegistry.getProbes().stream()
+                .filter(p -> includes == null || includes.contains(p.getName()))
                 .filter(p -> probesRegistry.getProbeSeverity(p).ordinal() >= ProbeSeverity.valueOf(severityThreshold.name()).ordinal())
                 .map(GqlProbe::new).collect(Collectors.toList());
     }

--- a/src/main/java/org/jahia/modules/sam/graphql/ServerAvailabilityQuery.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/ServerAvailabilityQuery.java
@@ -1,13 +1,11 @@
 package org.jahia.modules.sam.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminQuery;
 import org.jahia.modules.sam.TasksIdentificationService;
 import org.jahia.osgi.BundleUtils;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,8 +27,10 @@ public class ServerAvailabilityQuery {
 
     @GraphQLField
     @GraphQLDescription("HealthCheck node")
-    public GqlHealthCheck getHealthCheck(@GraphQLName("severity") GqlProbeSeverity severity) {
-        return new GqlHealthCheck(severity);
+    public GqlHealthCheck getHealthCheck(
+            @GraphQLName("severity") @GraphQLDescription("Returns SAM probes with this severity or higher") GqlProbeSeverity severity,
+            @GraphQLName("includes") @GraphQLDescription("Returns only SAM probes with probe names included in this list") Collection<@GraphQLNonNull String> includes) {
+        return new GqlHealthCheck(severity, includes);
     }
 
     @GraphQLField

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.HealthCheckServlet.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.HealthCheckServlet.cfg
@@ -1,5 +1,6 @@
 # default configuration
 severity.default=MEDIUM
+includes.default=
 
 status.threshold=RED
 status.code=503

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -8,7 +8,8 @@
     "extends": [
         "@jahia",
         "plugin:cypress/recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "plugin:chai-friendly/recommended"
     ],
     "rules": {
         "react/boolean-prop-naming": ["error", { "rule": "^((is|has)[A-Z]([A-Za-z0-9]?)+|disabled|readOnly|autoFocus)"}],

--- a/tests/cypress/e2e/api/checkProbes.spec.ts
+++ b/tests/cypress/e2e/api/checkProbes.spec.ts
@@ -33,6 +33,43 @@ describe('Health check', () => {
         });
     });
 
+    it('Filters with "includes" parameter', () => {
+        cy.runProvisioningScript({fileName: 'test-disable.json'});
+
+        cy.waitUntil(() => cy.task('sshCommand', sshCommands)
+            .then(waitUntilTestFcnDisable), waitUntilOptions);
+
+        console.log('Return with blank filter');
+        healthCheck('LOW', []).should(r => {
+            expect(r.probes).to.be.empty;
+        });
+
+        console.log('Return one probe');
+        healthCheck('LOW', 'FileDatastore').should(r => {
+            expect(r.probes.length).to.be.eq(1);
+            expect(r.probes[0].name).to.be.eq('FileDatastore');
+        });
+
+        console.log('Return more than one probe');
+        healthCheck('LOW', ['FileDatastore', 'DBConnectivity']).should(r => {
+            expect(r.probes.length).to.be.eq(2);
+            const probeNames = r.probes?.map(p => p.name);
+            expect('FileDatastore').to.be.oneOf(probeNames);
+            expect('DBConnectivity').to.be.oneOf(probeNames);
+        });
+
+        console.log('Filter with only invalid probe');
+        healthCheck('LOW', ['UndefinedProbe']).should(r => {
+            expect(r.probes).to.be.empty;
+        });
+
+        console.log('Filter invalid probe');
+        healthCheck('LOW', ['FileDatastore', 'UndefinedProbe']).should(r => {
+            expect(r.probes.length).to.be.eq(1);
+            expect(r.probes[0].name).to.be.eq('FileDatastore');
+        });
+    });
+
     it('Check healthcheck with one HIGH probe RED, asking low', () => {
         cy.runProvisioningScript({fileName: 'test-enable.json'});
 

--- a/tests/cypress/e2e/api/healthCheckServlet.spec.ts
+++ b/tests/cypress/e2e/api/healthCheckServlet.spec.ts
@@ -1,0 +1,61 @@
+const healthcheck = qs => {
+    return cy.request({
+        url: `${Cypress.config().baseUrl}/modules/healthcheck`,
+        qs,
+        headers: {
+            referer: Cypress.config().baseUrl
+        },
+        auth: {
+            user: 'root',
+            pass: Cypress.env('SUPER_USER_PASSWORD'),
+            sendImmediately: true
+        },
+        failOnStatusCode: false
+    });
+};
+
+describe('healthcheck REST API test', () => {
+    it('should return using "includes" parameter', () => {
+        console.log('Return with no filter');
+        healthcheck({}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.not.be.empty;
+        });
+
+        console.log('Return with empty filter');
+        healthcheck({includes: undefined}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.not.be.empty;
+        });
+
+        console.log('Return one probe');
+        healthcheck({includes: 'FileDatastore'}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes?.length).to.eq(1);
+            expect(response.body.probes[0]?.name).to.eq('FileDatastore');
+        });
+
+        console.log('Return more than one probe');
+        healthcheck({includes: 'FileDatastore,DBConnectivity'}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes.length).to.be.eq(2);
+            const probeNames = response.body.probes?.map(r => r.name);
+            expect('FileDatastore').to.be.oneOf(probeNames);
+            expect('DBConnectivity').to.be.oneOf(probeNames);
+        });
+
+        console.log('Filter with only invalid probe');
+        healthcheck({includes: 'UndefinedProbe'}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes).to.be.empty;
+        });
+
+        console.log('Filter invalid probe');
+        healthcheck({includes: 'FileDatastore,UndefinedProbe'}).should(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body.probes.length).to.be.eq(1);
+            const probeNames = response.body.probes?.map(r => r.name);
+            expect('FileDatastore').to.be.oneOf(probeNames);
+        });
+    });
+});

--- a/tests/cypress/e2e/api/shutdown.spec.ts
+++ b/tests/cypress/e2e/api/shutdown.spec.ts
@@ -22,7 +22,6 @@ describe('Shutdown via API - mutation.admin.jahia.shutdown', () => {
             mutationFile: 'shutdown.graphql'
         }).should(response => {
             cy.log('Requested shutdown');
-            // eslint-disable-next-line no-unused-expressions
             expect(response.data.admin.jahia.shutdown).to.be.false;
             const completeShutdown = new Date().getTime();
             const executionTime = completeShutdown - startShutdown;
@@ -44,7 +43,6 @@ describe('Shutdown via API - mutation.admin.jahia.shutdown', () => {
             mutationFile: 'shutdown.graphql'
         }).should(response => {
             cy.log('Requested shutdown');
-            // eslint-disable-next-line no-unused-expressions
             expect(response.data.admin.jahia.shutdown).to.be.false;
             const completeShutdown = new Date().getTime();
             const executionTime = completeShutdown - startShutdown;
@@ -64,7 +62,6 @@ describe('Shutdown via API - mutation.admin.jahia.shutdown', () => {
             },
             mutationFile: 'shutdown.graphql'
         }).should(response => {
-            // eslint-disable-next-line no-unused-expressions
             expect(response.data.admin.jahia.shutdown).to.be.true;
             const completeShutdown = new Date().getTime();
             const executionTime = completeShutdown - startShutdown;
@@ -84,7 +81,6 @@ describe('Shutdown via API - mutation.admin.jahia.shutdown', () => {
             mutationFile: 'shutdown.graphql'
         }).should(response => {
             cy.log('Requested shutdown');
-            // eslint-disable-next-line no-unused-expressions
             expect(response.data.admin.jahia.shutdown).to.be.true;
             const completeShutdown = new Date().getTime();
             const executionTime = completeShutdown - startShutdown;

--- a/tests/cypress/fixtures/healthcheck.graphql
+++ b/tests/cypress/fixtures/healthcheck.graphql
@@ -1,7 +1,7 @@
-query($severity: GqlProbeSeverity) {
+query($severity: GqlProbeSeverity, $includes: [String!]) {
     admin {
         jahia {
-            healthCheck(severity: $severity) {
+            healthCheck(severity: $severity, includes: $includes) {
                 status {
                     health
                     message

--- a/tests/cypress/support/gql.ts
+++ b/tests/cypress/support/gql.ts
@@ -37,7 +37,7 @@ export const deleteTask = (taskService: string, taskName: string, auth?: AuthMet
     });
 };
 
-export const healthCheck = (severity: string, auth?: AuthMethod): Chainable<any> => {
+export const healthCheck = (severity: string, includes?: [string?], auth?: AuthMethod): Chainable<any> => {
     if (auth) {
         cy.apolloClient(auth);
     }
@@ -45,9 +45,7 @@ export const healthCheck = (severity: string, auth?: AuthMethod): Chainable<any>
     return cy
         .apollo({
             queryFile: 'healthcheck.graphql',
-            variables: {
-                severity
-            },
+            variables: {severity, includes},
             errorPolicy: 'all'
         })
         .then((response: any) => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,6 +22,7 @@
     "cypress-wait-until": "^1.7.2",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-json": "^3.1.0",
@@ -31,8 +32,8 @@
     "mochawesome": "^7.0.1",
     "mochawesome-merge": "^4.2.0",
     "mochawesome-report-generator": "^6.0.1",
+    "node-ssh": "^12.0.4",
     "prettier": "^2.4.0",
-    "typescript": "^4.4.2",
-    "node-ssh": "^12.0.4"
+    "typescript": "^4.4.2"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1596,6 +1596,11 @@ eslint-config-xo@^0.27.2:
   resolved "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.27.2.tgz#71aff3d5b5554e9e5b5e1853e21da7799bb53f1f"
   integrity sha512-qEuZP0zNQkWpOdNZvWnfY2GNp1AZ33uXgeOXl4DN5YVLHFvekHbeSM2FFZ8A489fp1rCCColVRlJsYMf28o4DA==
 
+eslint-plugin-chai-friendly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.0.0.tgz#84631f0a415914f15fbaee2ccbf77dc6f3d2cc8a"
+  integrity sha512-M7pDQ/H5IiMz1LsfNi7Js4LvKx7cx0VMJHT/u1d35GOXxkQdJ2vAeaLC5q6GW126KVOnUMJ8WvBMWWLxtfdcog==
+
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22625

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

2.8-SN backport to https://github.com/Jahia/server-availability-manager/pull/127

Fix eslint issues with `expect` statements by installing chai-friendly eslint plugin