### PR TITLE
BACKLOG-22923: Use MXBean for ThreadLoadAverage

### DIFF
--- a/src/main/java/org/jahia/modules/sam/load/provider/ThreadLoadAverage.java
+++ b/src/main/java/org/jahia/modules/sam/load/provider/ThreadLoadAverage.java
@@ -46,6 +46,8 @@ import org.jahia.modules.sam.load.LoadAverageProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
+import java.lang.management.ManagementFactory;
+
 /**
  * Load average class based on active thread count.
  */
@@ -65,7 +67,7 @@ public class ThreadLoadAverage extends LoadAverageProvider {
 
     @Override
     public double getValue() {
-        return Thread.getAllStackTraces().keySet().size();
+        return ManagementFactory.getThreadMXBean().getThreadCount();
     }
 
 }


### PR DESCRIPTION
## JIRA

[BACKLOG-22923](https://jira.jahia.org/browse/BACKLOG-22923)

## Description

Use MXBean for Thread Load
