### PR TITLE
BACKLOG-22954 Add rendering probe status check

### DIFF
--- a/tests/cypress/e2e/api/checkProbes.spec.ts
+++ b/tests/cypress/e2e/api/checkProbes.spec.ts
@@ -192,4 +192,11 @@ describe('Health check', () => {
             expect(dummyProbe.status.health).to.eq('GREEN');
         });
     });
+
+    it('Checks if RenderingChain is green', () => {
+        healthCheck('CRITICAL', ['RenderingChain']).should(r => {
+            expect(r.status.health).to.eq('GREEN');
+            expect(r.probes.length).to.be.eq(1);
+        });
+    });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22954

## Description

Add rendering probe status check