### PR TITLE
BACKLOG-22929: Fix rendering chain and cluster consistency probe conflict

### DIFF
--- a/src/main/java/org/jahia/modules/sam/healthcheck/probes/RenderingChainProbe.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/probes/RenderingChainProbe.java
@@ -51,17 +51,10 @@ public class RenderingChainProbe implements Probe {
     @Activate
     public void start() throws RepositoryException {
         textTest = "Rendering Chain Test initialized at " + ISO8601.format(Calendar.getInstance());
-        JahiaSitesService jahiaSitesService = (JahiaSitesService) SpringContextSingleton.getBean("JahiaSitesService");
-
-        Locale locale = JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
-            JCRSessionFactory sessionFactory = JCRSessionFactory.getInstance();
-            JahiaSite defaultSite = jahiaSitesService.getDefaultSite(session);
-            return Locale.forLanguageTag(defaultSite.getDefaultLanguage());
-        });
 
         boolean isClusterActivated = SettingsBean.getInstance().isClusterActivated();
         String nodeSuffix = (isClusterActivated && journalEventReader != null) ? journalEventReader.getNodeId() : "";
-        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.LIVE_WORKSPACE, locale, session -> {
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.LIVE_WORKSPACE, null, session -> {
             String parentPath = "/sites/systemsite/home";
             String nodeName = "renderingChainTest" + nodeSuffix;
             nodePath = parentPath + "/" + nodeName;
@@ -124,12 +117,7 @@ public class RenderingChainProbe implements Probe {
         try {
             JCRSessionFactory sessionFactory = JCRSessionFactory.getInstance();
             RenderContext renderContext = new RenderContext(request, response, sessionFactory.getCurrentUser());
-            JahiaSite defaultSite = jahiaSitesService.getDefaultSite();
-            if (defaultSite == null) {
-                return new ProbeStatus("No site installed, postponing rendering test.", ProbeStatus.Health.GREEN);
-            }
-
-            JCRSessionWrapper currentUserSession = sessionFactory.getCurrentUserSession(Constants.LIVE_WORKSPACE, Locale.forLanguageTag(defaultSite.getDefaultLanguage()));
+            JCRSessionWrapper currentUserSession = sessionFactory.getCurrentUserSession(Constants.LIVE_WORKSPACE, null);
             if (!currentUserSession.nodeExists(nodePath)) {
                 // something wrong happened in the setup/activate, not necessarily with the rendering chain
                 return new ProbeStatus("Rendering Chain test node not found", ProbeStatus.Health.YELLOW);

--- a/src/main/java/org/jahia/modules/sam/healthcheck/probes/RenderingChainProbe.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/probes/RenderingChainProbe.java
@@ -11,6 +11,7 @@ import org.jahia.services.SpringContextSingleton;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.content.decorator.JCRSiteNode;
 import org.jahia.services.events.JournalEventReader;
 import org.jahia.services.render.RenderContext;
@@ -19,11 +20,14 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.sites.JahiaSite;
 import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.settings.SettingsBean;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.text.MessageFormat;
@@ -33,9 +37,62 @@ import java.util.Locale;
 @Component(service = Probe.class, immediate = true)
 public class RenderingChainProbe implements Probe {
 
-    private Logger logger = LoggerFactory.getLogger(RenderingChainProbe.class);
+    private final Logger logger = LoggerFactory.getLogger(RenderingChainProbe.class);
 
     private JournalEventReader journalEventReader;
+
+    private String textTest;
+    private String nodePath;
+
+    /**
+     * Create the rendering chain test node in LIVE workspace
+     * @throws RepositoryException
+     */
+    @Activate
+    public void start() throws RepositoryException {
+        textTest = "Rendering Chain Test initialized at " + ISO8601.format(Calendar.getInstance());
+        JahiaSitesService jahiaSitesService = (JahiaSitesService) SpringContextSingleton.getBean("JahiaSitesService");
+
+        Locale locale = JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
+            JCRSessionFactory sessionFactory = JCRSessionFactory.getInstance();
+            JahiaSite defaultSite = jahiaSitesService.getDefaultSite(session);
+            return Locale.forLanguageTag(defaultSite.getDefaultLanguage());
+        });
+
+        boolean isClusterActivated = SettingsBean.getInstance().isClusterActivated();
+        String nodeSuffix = (isClusterActivated && journalEventReader != null) ? journalEventReader.getNodeId() : "";
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.LIVE_WORKSPACE, locale, session -> {
+            String parentPath = "/sites/systemsite/home";
+            String nodeName = "renderingChainTest" + nodeSuffix;
+            nodePath = parentPath + "/" + nodeName;
+
+            JCRNodeWrapper testNode;
+            if (!session.nodeExists(nodePath)) {
+                logger.debug("Creating rendering chain test node at {}", nodePath);
+                JCRNodeWrapper home = session.getNode(parentPath);
+                testNode = home.addNode(nodeName, "sam:renderingChain");
+                testNode.setProperty("jcr:title", "Rendering Chain Test Node");
+            } else {
+                testNode = session.getNode(nodePath);
+            }
+            testNode.setProperty("text", textTest);
+            session.save();
+
+            return null;
+        });
+    }
+
+    @Deactivate
+    public void stop() throws RepositoryException {
+        JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
+            if (session.nodeExists(nodePath)) {
+                logger.debug("Removing rendering chain test node at {}", nodePath);
+                session.getNode(nodePath).remove();
+                session.save();
+            }
+            return null;
+        });
+    }
 
     @Reference
     public void setJournalEventReader(JournalEventReader journalEventReader) {
@@ -54,12 +111,6 @@ public class RenderingChainProbe implements Probe {
 
     @Override
     public ProbeStatus getStatus(HttpServletRequest request, HttpServletResponse response) {
-        String nodeSuffix = "";
-
-        if (SettingsBean.getInstance().isClusterActivated() && journalEventReader != null) {
-            nodeSuffix = journalEventReader.getNodeId();
-        }
-
         RenderService renderService = (RenderService) SpringContextSingleton.getBean("RenderService");
         JahiaSitesService jahiaSitesService = (JahiaSitesService) SpringContextSingleton.getBean("JahiaSitesService");
         if (renderService == null) {
@@ -77,20 +128,13 @@ public class RenderingChainProbe implements Probe {
             if (defaultSite == null) {
                 return new ProbeStatus("No site installed, postponing rendering test.", ProbeStatus.Health.GREEN);
             }
-            String textTest = MessageFormat.format("Rendering Chain Test done at {0}", ISO8601.format(Calendar.getInstance()));
+
             JCRSessionWrapper currentUserSession = sessionFactory.getCurrentUserSession(Constants.LIVE_WORKSPACE, Locale.forLanguageTag(defaultSite.getDefaultLanguage()));
-            JCRNodeWrapper testNode;
-            if (!currentUserSession.nodeExists("/sites/systemsite/home/renderingChainTest" + nodeSuffix)) {
-                JCRNodeWrapper home = currentUserSession.getNode("/sites/systemsite/home");
-                testNode = home.addNode("renderingChainTest" + nodeSuffix, "sam:renderingChain");
-                testNode.setProperty("text", textTest);
-                testNode.setProperty("jcr:title", "Rendering Chain Test Node");
-                currentUserSession.save();
-            } else {
-                testNode = currentUserSession.getNode("/sites/systemsite/home/renderingChainTest" + nodeSuffix);
-                testNode.setProperty("text", textTest);
-                currentUserSession.save();
+            if (!currentUserSession.nodeExists(nodePath)) {
+                // something wrong happened in the setup/activate, not necessarily with the rendering chain
+                return new ProbeStatus("Rendering Chain test node not found", ProbeStatus.Health.YELLOW);
             }
+            JCRNodeWrapper testNode = currentUserSession.getNode(nodePath);
             JCRNodeWrapper mainNode = NodeHelper.getNodeInLanguage(testNode, "en");
             Resource r = new Resource(mainNode, "html", "default", "module");
             renderContext.setMainResource(r);

--- a/src/main/resources/sam_renderingChain/html/renderingChain.properties
+++ b/src/main/resources/sam_renderingChain/html/renderingChain.properties
@@ -1,5 +1,5 @@
 #cache.mainResource=true
-#cache.expiration=0
+cache.expiration=0
 #cache.perUser=true
 #cache.requestParameters=page,begin*
 #cache.requestParameters=*


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22929

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Refactor RenderingChainProbe to avoid writing to the node for each status check that is causing issues with ClusterConsistencyProbe. Add a clean up step for the node as well on module deactivation.

Disable caching to make sure that we are going through all the filters in the rendering chain every check.

Also removed requirement of having a default site and use fallback locale instead when creating the node in systemsite.