### PR TITLE
BACKLOG-22929: Fix startup issue when creating rendering chain test node

### DIFF
--- a/src/main/java/org/jahia/modules/sam/events/SystemSiteHomeEventListener.java
+++ b/src/main/java/org/jahia/modules/sam/events/SystemSiteHomeEventListener.java
@@ -28,16 +28,13 @@ import org.jahia.modules.sam.healthcheck.probes.RenderingChainProbe;
 import org.jahia.services.content.DefaultEventListener;
 import org.jahia.services.content.JCRObservationManager;
 import org.jahia.settings.SettingsBean;
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
-import javax.jcr.observation.EventListener;
 import java.util.Set;
 
-@Component(service = EventListener.class, immediate = true)
 public class SystemSiteHomeEventListener extends DefaultEventListener {
     private final Logger logger = LoggerFactory.getLogger(SystemSiteHomeEventListener.class);
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22929

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue on startup trying to create rendering chain test node on systemsite/home when it has not been initialized yet.

Create an event listener to be able to create the test node when systemsite/home has been created. If in cluster, we only react on events received in processing node.
