### PR TITLE
QA-15262: Catch remote bundle information exception when calling probe status. 

### DIFF
--- a/src/main/java/org/jahia/modules/sam/graphql/GqlProbe.java
+++ b/src/main/java/org/jahia/modules/sam/graphql/GqlProbe.java
@@ -45,7 +45,11 @@ public class GqlProbe {
     @GraphQLField
     @GraphQLDescription("Status reported by the probe (GREEN to RED)")
     public GqlProbeStatus getStatus() {
-        ProbeStatus status = probe.getStatus();
-        return new GqlProbeStatus(status.getMessage(), GqlProbeStatus.GqlProbeHealth.valueOf(status.getHealth().name()));
+        try {
+            ProbeStatus status = probe.getStatus();
+            return new GqlProbeStatus(status.getMessage(), GqlProbeStatus.GqlProbeHealth.valueOf(status.getHealth().name()));
+        } catch (Throwable e) {
+            return new GqlProbeStatus("Error getting probe status: " + e.getMessage(), GqlProbeStatus.GqlProbeHealth.RED);
+        }
     }
 }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-15262

## Description

BACKPORT of : https://github.com/Jahia/server-availability-manager/pull/160
When a probe status is called over cluster and a node does not respond, the exception encapsulated in a FailingMap cause an exception as soons as a method is called on it (size()) in GqlProbe

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation