### PR TITLE
BACKLOG-23376: Bumped up the yellow threshold for the SearchIndexProbe

### DIFF
--- a/src/main/java/org/jahia/modules/sam/healthcheck/probes/SearchIndexProbe.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/probes/SearchIndexProbe.java
@@ -36,7 +36,7 @@ public class SearchIndexProbe implements Probe {
     }
 
 
-    private int queryAVGLastMinuteYellowThreshold = 5;
+    private int queryAVGLastMinuteYellowThreshold = 10;
     private int queryAVGLastMinuteRedThreshold = 50;
 
     private static final String QUERY_AVG_LAST_MINUTE_YELLOW_THRESHOLD_CONFIG_PROPERTY = "queryAVGLastMinuteYellowThreshold";

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.sam.healthcheck.ProbesRegistry.cfg
@@ -14,7 +14,7 @@
 #probes.ServerLoad.nodeCacheLoadRedThreshold=2000
 
 #example of SearchIndex probe config in ms
-#probes.SearchIndex.queryAVGLastMinuteYellowThreshold=5
+#probes.SearchIndex.queryAVGLastMinuteYellowThreshold=10
 #probes.SearchIndex.queryAVGLastMinuteRedThreshold=50
 
 #example of JahiaErrorsProbe probe config


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23376

Change done following a discussion with @jkevan.

Our tests rely more on the SAM status and we've seen quite a few occurrences where this probe was returning yellow due to the low threshold.

For that type of operation, it is considered that 5ms is too low, 10ms is more realistic and does not highlight a performance degradation.