### PR TITLE
fix: Add missing export package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,10 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-signature>MC0CFG0N9dm+zc3DqFiI46a7F2e44LfUAhUAg1nwQrUqcDvx51xZ/uxmhsnNoYk=</jahia-module-signature>
-        <export-package>org.jahia.modules.sam</export-package>
+        <export-package>
+            org.jahia.modules.sam,
+            org.jahia.modules.sam.model
+        </export-package>
         <import-package>
             graphql.annotations.annotationTypes;version="[7.2,99)",
             graphql.schema;version="[13.0,22)",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Add the missing export package for `org.jahia.modules.sam.model`, that is used by exposed packages but not exposed itself.
Because of that, there is currently a warning during the build:
```
 [WARNING] Bundle org.jahia.modules:server-availability-manager:bundle:3.4.0-SNAPSHOT : Export org.jahia.modules.sam, has 1, private references [org.jahia.modules.sam.model]
```
