### PR TITLE
chore: bump plugins versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,22 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -217,7 +229,6 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.9</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
### Description
Bump the versions for the plugins `maven-clean-plugin` and `cyclonedx-maven-plugin`.
The last one fixes a warning during the build, when creating the BOM:
```
[INFO] --- cyclonedx:2.7.9:makeAggregateBom (default) @ server-availability-manager ---
[INFO] CycloneDX: Resolving Dependencies
[INFO] CycloneDX: Creating BOM version 1.4 with 0 component(s)
[INFO] CycloneDX: Writing and validating BOM (JSON): /Users/baptistegrimaud/Documents/code/jahia/server-availability-manager/target/java-bom.cdx.json
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[INFO]            attaching as server-availability-manager-3.4.0-SNAPSHOT-cyclonedx.json
```
> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
