### PR TITLE
fix: make providers list thread safe

### DIFF
--- a/src/main/java/org/jahia/modules/sam/load/LoadAverageServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sam/load/LoadAverageServiceImpl.java
@@ -56,10 +56,10 @@ import java.util.stream.Collectors;
 @Component(immediate = true, service = LoadAverageService.class, scope = ServiceScope.SINGLETON)
 public class LoadAverageServiceImpl implements LoadAverageService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoadAverageService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadAverageServiceImpl.class);
     @Reference(service = LoadAverageProvider.class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC,
             bind = "addProvider", unbind = "removeProvider")
-    private volatile List<LoadAverageProvider> providers = new ArrayList<>();
+    private final List<LoadAverageProvider> providers = Collections.synchronizedList(new ArrayList<>());
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final Map<String, ScheduledFuture<?>> schedules = new HashMap<>();
     private long calcFreqMillis = 5000;


### PR DESCRIPTION
### Description
Makes the providers list thread safe and refines the logger usage by referencing the implementing class.
Addresses [this SonarQube issue](https://sonarqube.jahia.com/project/issues?resolved=false&types=BUG&id=org.jahia.modules%3Aserver-availability-manager&open=AZAKzqGf2oUwUBxTtBb_).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
