### PR TITLE
test: use a module instead of a bundle to test multiple versions

### DIFF
--- a/tests/cypress/e2e/api/multipleVersions.spec.ts
+++ b/tests/cypress/e2e/api/multipleVersions.spec.ts
@@ -38,26 +38,4 @@ describe('Multiple (Bundle|Module) probe test', () => {
             });
         });
     });
-
-    describe('Test multiple version of a bundle', () => {
-        beforeEach(() => {
-            cy.runProvisioningScript({fileName: 'multipleVersions/install-bundle.json'});
-        });
-
-        afterEach(() => {
-            cy.runProvisioningScript({fileName: 'multipleVersions/uninstall-bundle.json'});
-        });
-
-        it('Checks the MultipleBundleVersions is reporting duplicate', () => {
-            healthCheck('LOW').should(r => {
-                let probeToCheck = r.probes.find(probe => probe.name === 'MultipleBundleVersions');
-                expect(probeToCheck.status.health).to.eq(isDevelopmentOperatingMode ? 'YELLOW' : 'RED');
-                expect(probeToCheck.status.message).to.contain('org.jahia.bundles.maintenancefilter');
-                expect(probeToCheck.status.message).to.contain('8.2.0.3: INSTALLED');
-
-                probeToCheck = r.probes.find(probe => probe.name === 'MultipleModuleVersions');
-                expect(probeToCheck.status.health).to.eq('GREEN');
-            });
-        });
-    });
 });

--- a/tests/cypress/fixtures/multipleVersions/install-bundle.json
+++ b/tests/cypress/fixtures/multipleVersions/install-bundle.json
@@ -1,5 +1,0 @@
-[
-  {
-    "installBundle": "mvn:org.jahia.bundles/org.jahia.bundles.maintenancefilter/8.2.0.3"
-  }
-]

--- a/tests/cypress/fixtures/multipleVersions/uninstall-bundle.json
+++ b/tests/cypress/fixtures/multipleVersions/uninstall-bundle.json
@@ -1,5 +1,0 @@
-[
-  {
-    "uninstallBundle": "org.jahia.bundles.maintenancefilter/8.2.0.3"
-  }
-]


### PR DESCRIPTION
### Description

Since https://github.com/Jahia/jahia-private/pull/3626, only modules and fragments can be installed.
Meaning the test to check that multiple versions of the same bundle are reported as duplicates, is not relevant anymore (and can't be tested as the installation of a bundle is no longer possible in the setup of the test).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
