### PR TITLE
chore: Make Goat team as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# These owners will be the default owners for everything in the repository.
+# Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+
+# See documentation here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+
+* @Jahia/team-goat


### PR DESCRIPTION
### Description
So the team is automatically added as reviewer.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
