### PR TITLE
ci: Fix SBOM artifacts name

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           dependencytrack_hostname: ${{ vars.DEPENDENCYTRACK_HOSTNAME }}
           dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          sbom_artifacts: "build-artifacts"
 
   integration-tests-standalone:
     uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2


### PR DESCRIPTION
### Description
The [default value](https://github.com/Jahia/jahia-modules-action/blob/main/sbom-processing/action.yml#L22) for the _SBOM processing_ action is different from the [default value](https://github.com/Jahia/jahia-modules-action/blob/main/build-step-mvn/action.yml#L32) for the artifacts built in the _Build step for Jahia MVN module_ action, and has to be specified in the workflow.
It was removed by mistake in https://github.com/Jahia/server-availability-manager/pull/195/files#diff-52f2d11ee9848eab8314dccf0822c7852a568fed99f06737c13aa214c3ab1fb8L53.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
