### PR TITLE
ci: Set the missing github_slug param for the Sonar analysis

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,3 +19,4 @@ jobs:
     with:
       module_id: server-availability-manager
       git_branch: ${{ matrix.git_branch }}
+      github_slug: 'jahia/server-availability-manager'


### PR DESCRIPTION
### Description
Since https://github.com/Jahia/jahia-modules-action/pull/240, the `github_slug` parameter is now mandatory for the reusable _Sonar Analysis_.
Without it, the [workflow fails](https://github.com/Jahia/server-availability-manager/actions/runs/14529401078/workflow):
```
Invalid workflow file

The workflow is not valid. .github/workflows/schedule-sonar.yml (Line: 12, Col: 11): Input github_slug is required, but not provided while calling.
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
