### PR TITLE
ci: Fix nightly tests (snapshot)

### DIFF
--- a/.github/workflows/nightly-snapshot.yml
+++ b/.github/workflows/nightly-snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     secrets: inherit
     with:
-      jahia_image: jahia/jahia-ee:8-SNAPSHOT
+      jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
       module_id: server-availability-manager
       testrail_project: Server Availability Manager
       pagerduty_incident_service: server-availability-manager-JahiaSN


### PR DESCRIPTION
### Description
The wrong `jahia_image` parameter has been set when moving to reusable workflows in https://github.com/Jahia/server-availability-manager/pull/195/files#diff-21ac65efe9689f1a3dd834019954b6e0597c6db6204ebebe6d5174c05121ac51R13.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
