### PR TITLE
ci: configure reusable workflow for manual run

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -8,7 +8,7 @@ on:
       jahia_image:
         description: 'Jahia Image'
         required: true
-        default: 'jahia/jahia-ee:8.1'
+        default: 'ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT'
       manifest:
         description: 'Provisioning manifest. Can be a local repository file in the tests folder or a publicly accessible link'
         required: true
@@ -16,59 +16,13 @@ on:
 
 jobs:
   integration-tests:
-    name: Integration Tests
-    runs-on: self-hosted
-    timeout-minutes: 30
-    steps:
-      - uses: jahia/jahia-modules-action/helper@v2
-      - uses: actions/checkout@v3
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        with:
-          version: '1.29.2'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 'lts/*'
-      - uses: jahia/jahia-modules-action/integration-tests@v2
-        with:
-          module_id: server-avaiblaility-manager
-          testrail_project: Server Availability Manager
-          timeout_minutes: 20
-          jahia_image: ${{ github.event.inputs.jahia_image }}
-          should_use_build_artifacts: false
-          should_skip_artifacts: true
-          should_skip_notifications: true
-          should_skip_testrail: true
-          should_skip_zencrepes: false
-          github_artifact_name: sam-artifacts-${{ github.run_number }}
-          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-          tests_manifest: ${{ github.event.inputs.manifest }}
-          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-          docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          docker_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Tests Report
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'
-
-      # Tmate only starts if any of the previous steps fails.
-      # Be careful since it also means that if a step fails the workflow will
-      # keep running until it reaches the timeout.
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+    uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    secrets: inherit
+    with:
+      jahia_image: ${{ github.event.inputs.jahia_image }}
+      module_id: server-availability-manager
+      testrail_project: Server Availability Manager
+      should_skip_testrail: true
+      pagerduty_skip_notification: true
+      provisioning_manifest: ${{ github.event.inputs.manifest }}
+      module_branch: ${{ github.ref }}


### PR DESCRIPTION
### Description

Use the reusable workflow on the 2.x branch similar to what is in place on [`main`](https://github.com/Jahia/server-availability-manager/tree/main).
(Partial backport of https://github.com/Jahia/server-availability-manager/commit/f86560b559b2c4555075a56682b62339f5cddcbb - but only the manual run workflow is updated as that's the only one relevant for a maintenance branch).

Without it, the manual run is failing (see https://github.com/Jahia/server-availability-manager/actions/runs/20105109087). 
Now, the workflow successfully completes (see https://github.com/Jahia/server-availability-manager/actions/runs/20110612096).
Refer to https://jahia.slack.com/archives/C0A0Q51FXSS/p1765376587197369 for the full context.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
