### PR TITLE
fix: correct healthcheck scope and grants

### DIFF
--- a/.chachalog/IcNBgaBE.md
+++ b/.chachalog/IcNBgaBE.md
@@ -1,0 +1,7 @@
+---
+# Allowed version bumps: patch, minor, major
+server-availability-manager: patch
+---
+
+Fixed the Health check endpoint authorization to work reliably under all security profiles.
+

--- a/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
@@ -79,7 +79,7 @@ public class HealthCheckServlet extends HttpServlet {
         StringWriter writer = new StringWriter();
         HttpServletResponse responseWrapper = new HealthCheckHttpServletResponseWrapper(resp, writer);
 
-        permissionService.addScopes(Collections.singleton("graphql"), req);
+        permissionService.addScopes(Collections.singleton("healthcheck"), req);
         gql.service(requestWrapper, responseWrapper);
 
         try {

--- a/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
@@ -10,5 +10,6 @@ healthcheck:
     - api: graphql.AdminQuery.jahia
     - api: graphql.JahiaAdminQuery.healthCheck
     - api: graphql.GqlHealthCheck
+    - api: graphql.GqlHealthCheckStatus
     - api: graphql.GqlProbe
     - api: graphql.GqlProbeStatus


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4702.

Caused by https://github.com/Jahia/server-availability-manager/pull/47.

### Description
This PR fixes authorization issues with the `/modules/healthcheck` endpoint:

- The servlet now adds the correct "healthcheck" scope (the one provided by SAM module) instead of "graphql": `PermissionService#addScopes(...)` only allows scopes that are already defined in the authorization configuration; if an undefined scope is passed, it is ignored and does not grant any permissions.
- The `org.jahia.bundles.api.authorization-sam.yml` grants for the "healthcheck" scope now include `graphql.GqlHealthCheckStatus`, which is the return type of [the status](https://github.com/Jahia/server-availability-manager/blob/6f417e0c4829b321b8f2ccadc2520d3b64f4abcd/src/main/java/org/jahia/modules/sam/graphql/GqlHealthCheck.java#L42) for the GraphQL query used internally by the servlet:
```gql
admin {
  jahia {
    healthcheck {
      status {
        # rest of the query
      }
    }
  }
}
```

These changes ensure the health check endpoint works as expected under all security profiles and no longer returns 403 errors due to missing or misconfigured scopes,  in particular when using `security.profile=off`.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
