### PR TITLE
fix: correct healthcheck scope and grants - backport

### DIFF
--- a/.chachalog/IcNBgaBE.md
+++ b/.chachalog/IcNBgaBE.md
@@ -1,0 +1,7 @@
+---
+# Allowed version bumps: patch, minor, major
+server-availability-manager: patch
+---
+
+Fixed the Health check endpoint authorization to work reliably under all security profiles.
+

--- a/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
+++ b/src/main/java/org/jahia/modules/sam/healthcheck/HealthCheckServlet.java
@@ -119,7 +119,7 @@ public class HealthCheckServlet extends HttpServlet {
             }
         };
 
-        permissionService.addScopes(Collections.singleton("graphql"), req);
+        permissionService.addScopes(Collections.singleton("healthcheck"), req);
 
         gql.service(requestWrapper, responseWrapper);
 

--- a/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
@@ -10,6 +10,5 @@ healthcheck:
     - api: graphql.AdminQuery.jahia
     - api: graphql.JahiaAdminQuery.healthCheck
     - api: graphql.GqlHealthCheck
-    - api: graphql.GqlHealthCheckStatus
     - api: graphql.GqlProbe
     - api: graphql.GqlProbeStatus

--- a/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
@@ -10,5 +10,6 @@ healthcheck:
     - api: graphql.AdminQuery.jahia
     - api: graphql.JahiaAdminQuery.healthCheck
     - api: graphql.GqlHealthCheck
+    - api: graphql.GqlHealthCheckStatus
     - api: graphql.GqlProbe
     - api: graphql.GqlProbeStatus


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4702.
### Description
Backport #238 onto https://github.com/Jahia/server-availability-manager/tree/2_x.

**⚠️ Important ⚠️** : Requires https://github.com/Jahia/server-availability-manager/pull/241 to be merged first to be functional.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
