### PR TITLE
fix: Renamed authorization file and added missing scope - backport

### DIFF
--- a/.chachalog/_YA5cw4N.md
+++ b/.chachalog/_YA5cw4N.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+server-availability-manager: patch
+---
+
+Renamed the authorization configuration file and added a missing scope

--- a/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-sam.yml
@@ -11,3 +11,4 @@ healthcheck:
     - api: graphql.JahiaAdminQuery.healthCheck
     - api: graphql.GqlHealthCheck
     - api: graphql.GqlProbe
+    - api: graphql.GqlProbeStatus


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4702.
### Description
Backport of https://github.com/Jahia/server-availability-manager/pull/157 onto https://github.com/Jahia/server-availability-manager/tree/2_x.

**NB:** With an invalid name, the authorization configuration file is simply ignored (and the authorization is granted by the [provided "default" profile](https://github.com/Jahia/jahia-private/blob/JAHIA-8-1-9-X-BRANCH/bundles/security-filter/src/main/resources/META-INF/configuration-profiles/profile-default.yml)).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
